### PR TITLE
Some fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,9 +172,9 @@ pub fn delete_index(url: &str, index: &str) -> String {
 
 pub fn insert_document<T>(
     url: String,
-    index: &String,
-    mapping: &String,
-    doc_id: &String,
+    index: &str,
+    mapping: &str,
+    doc_id: &str,
     doc: &T,
 ) -> String
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,11 +133,8 @@ where
     // println!("{:?}", url);
 
     let mut req = Request::new(method, url);
-    {
-        // let mut headers = req.headers_mut();
-        let headers = req.headers_mut();
-        headers.set(ContentType::json());
-    }
+    req.headers_mut().set(ContentType::json());
+
     match *json_body {
         Some(_) => {
             let json_str = serde_json::to_string(&json_body).unwrap();

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -13,14 +13,14 @@ mod search;
 
 pub fn setup() {
     env_logger::init().unwrap();
-    let doc_id = "1".to_string();
-    delete_index(&build_url(""), &INDEX_NAME.to_string());
-    create_index(&build_url(""), &INDEX_NAME.to_string());
+    let doc_id = "1";
+    delete_index(&build_url(""), INDEX_NAME);
+    create_index(&build_url(""), INDEX_NAME);
     insert_document(
         build_url(""),
-        &INDEX_NAME.to_string(),
-        &MAPPING_NAME.to_string(),
-        &doc_id,
+        INDEX_NAME,
+        MAPPING_NAME,
+        doc_id,
         &example_tweet(),
     );
     let wait_time = time::Duration::from_secs(1);

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -15,7 +15,7 @@ fn search_all() {
         })),
     };
     let res: SearchResponse<Tweet> =
-        search(&build_url(""), &INDEX_NAME.to_string(), &query).unwrap();
+        search(&build_url(""), INDEX_NAME, &query).unwrap();
     assert_eq!(1, res.hits.hits.len());
     assert_eq!(example_tweet(), res.hits.hits[0]._source);
 }
@@ -27,7 +27,7 @@ fn search_all_boosted() {
         })),
     };
     let res: SearchResponse<Tweet> =
-        search(&build_url(""), &INDEX_NAME.to_string(), &query).unwrap();
+        search(&build_url(""), INDEX_NAME, &query).unwrap();
     assert_eq!(1, res.hits.hits.len());
     assert_eq!(example_tweet(), res.hits.hits[0]._source);
 }
@@ -42,7 +42,7 @@ fn search_term_query() {
         })),
     };
     let res: SearchResponse<Tweet> =
-        search(&build_url(""), &INDEX_NAME.to_string(), &query).unwrap();
+        search(&build_url(""), INDEX_NAME, &query).unwrap();
     // let res: Result<SearchResponse<Tweet>, serde_json::error::Error> =
     //     search(&build_url(""), &INDEX_NAME.to_string(), &query);
     // println!("{:?}", res);


### PR DESCRIPTION
Just some fixes I noticed during your stream. 

- You should never use a `&String`, use `&str` instead. The reason is that `&String` can be coerced by the compiler into `&str`, but not the other way around. You can use `&String` in places that require `&str` in function arguments.
- Since you made your `INDEX_NAME` and `MAPPING_NAME` are already references (to a certain location in the binary), you don't need to make them strings and then take references again. Unnecessary heap allocation.
- `req.headers_mut()` returns a value, where you can use method chaining, to basically put the result directly into `.set(ContentType::json())`. This "temporary" value lives until the end of the line, so it's the same thing as before, just with nicer syntax.